### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/dep/** linguist-vendored


### PR DESCRIPTION
Exclude anything in the `src/dep` folder from contributing to the language statistics since it is code from libraries. This way ZT will show up as a Zig project instead of a C project on GitHub. :)