### PR TITLE
Tweak to prevent windows-style carriage returns.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 src/dep/** linguist-vendored
+
+*.zig text eol=lf


### PR DESCRIPTION
Zig doesn't accept CRLF, only LF - was struggling to build on Windows. Thanks to @nektro for the fix suggestion.