### PR TITLE
Fixed the example program in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,8 +92,8 @@ const SampleData = struct {
 
 const SampleApplication = zt.App(SampleData);
 
-fn main() !void {
-    var context = SampleApplication.begin(std.heap.c_allocator);
+pub fn main() !void {
+    var context = try SampleApplication.begin(std.heap.c_allocator);
     // Config here,
     while(context.open) {
         context.beginFrame();


### PR DESCRIPTION
There were a couple of minor issues in the example program (missing `pub`, missing `try`).  This version of that example program now builds with 0.10.0-dev.376+15ef251a1