### PR TITLE
Various improments

### DIFF
--- a/src/zt/app.zig
+++ b/src/zt/app.zig
@@ -195,13 +195,15 @@ pub fn App(comptime Data: type) type {
                 initialized = true;
             }
         }
-        /// Starts the entire application! Returns errors if anything along the pipeline fails.
+
         pub fn begin(applicationAllocator: std.mem.Allocator) !*Context {
+            return beginWithData(applicationAllocator, .{});
+        }
+        /// Starts the entire application! Returns errors if anything along the pipeline fails.
+        pub fn beginWithData(applicationAllocator: std.mem.Allocator, data: Data) !*Context {
             var self: *Context = try applicationAllocator.create(Context);
             self.* = .{};
-            if (Data != void) {
-                self.data = .{};
-            }
+            self.data = data;
             self.allocator = applicationAllocator;
             self.input = std.ArrayList(InputEvent).init(applicationAllocator);
             try preInit();

--- a/src/zt/customComponents.zig
+++ b/src/zt/customComponents.zig
@@ -42,27 +42,27 @@ pub fn viewPort() ig.ImGuiID {
 
 /// If you ever need to format a string for use inside imgui, this will work the same as any format function.
 pub inline fn fmtTextForImgui(comptime fmt: []const u8, args: anytype) [:0]const u8 {
-    var alloc = zt.Allocators.ring();
-    return alloc.dupeZ(u8, std.fmt.allocPrint(alloc, fmt, args) catch unreachable) catch unreachable;
+    const alloc = zt.Allocators.ring();
+    return std.fmt.allocPrintZ(alloc, fmt, args) catch unreachable;
 }
 /// Uses a ring allocator to spit out imgui text using zig.ig's formatting library.
 pub fn text(comptime fmt: []const u8, args: anytype) void {
-    var textFormatted = fmtTextForImgui(fmt, args);
-    ig.igText("%s",textFormatted.ptr);
+    const textFormatted = fmtTextForImgui(fmt, args);
+    ig.igText("%s", textFormatted.ptr);
 }
 /// Uses a ring allocator to spit out imgui text using zig's formatting library, wrapping if needed.
 pub fn textWrap(comptime fmt: []const u8, args: anytype) void {
-    var textFormatted = fmtTextForImgui(fmt, args);
+    const textFormatted = fmtTextForImgui(fmt, args);
     ig.igTextWrapped("%s",textFormatted.ptr);
 }
 /// Uses a ring allocator to spit out imgui text using zig's formatting library, in the disabled color.
 pub fn textDisabled(comptime fmt: []const u8, args: anytype) void {
-    var textFormatted = fmtTextForImgui(fmt, args);
+    const textFormatted = fmtTextForImgui(fmt, args);
     ig.igTextDisabled("%s",textFormatted.ptr);
 }
 /// Uses a ring allocator to spit out imgui text using zig's formatting library with a custom color.
 pub fn textColor(comptime fmt: []const u8, color: ig.ImVec4, args: anytype) void {
-    var textFormatted = fmtTextForImgui(fmt, args);
+    const textFormatted = fmtTextForImgui(fmt, args);
     ig.igTextColored(color, "%s", textFormatted.ptr);
 }
 


### PR DESCRIPTION
- add `zt.App.beginWithData`. Maybe we should deprecate the original `zt.App(X).begin`? It doesn't initialized the app context well.
- use `allocPrintZ` in zg