### PR TITLE
Adds support for zig nightly without breaking Zig11

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,10 +1,16 @@
 .{
     .name = "ZT",
     .version = "0.1.0",
+    .paths = .{
+        "src",
+        "example",
+        "build.zig",
+        "build.zig.zon",
+    },
     .dependencies = .{
         .mach_glfw = .{
-         .url = "https://github.com/hexops/mach-glfw/archive/58a16012c33b047b9468cccb53ecd95835456121.tar.gz",
-         .hash = "1220dcf8c006b5bd91bb55c732eac6d95afe16247058f31348e1e2e071dfca7923db",
+            .url = "https://github.com/hexops/mach-glfw/archive/58a16012c33b047b9468cccb53ecd95835456121.tar.gz",
+            .hash = "1220dcf8c006b5bd91bb55c732eac6d95afe16247058f31348e1e2e071dfca7923db",
         },
         .xcode_frameworks = .{
             .url = "https://github.com/hexops/xcode-frameworks-pkg/archive/d486474a6af7fafd89e8314e0bf7eca4709f811b.tar.gz",
@@ -30,5 +36,5 @@
             .url = "https://pkg.machengine.org/x11-headers/991ad9bf599df04aaa5332e536712a8476838ee3.tar.gz",
             .hash = "12205bd95b9cc9cb08dd6b55f5842d8fae67a12eed01092c54f021060931815f711e",
         },
-    }
+    },
 }

--- a/example/src/main.zig
+++ b/example/src/main.zig
@@ -37,8 +37,8 @@ pub fn main() !void {
     var context = try SampleApplication.begin(std.heap.c_allocator);
 
     // Lets customize!
-    var io = ig.igGetIO();
-    var font = context.addFont(zt.path("public-sans.ttf"), 14.0);
+    const io = ig.igGetIO();
+    const font = context.addFont(zt.path("public-sans.ttf"), 14.0);
     io.*.FontDefault = font;
 
     // Set up state
@@ -63,7 +63,7 @@ pub fn main() !void {
         inspectContext(context);
 
         // Call into the selected demo:
-        var index = std.math.clamp(context.data.currentScene, 0, scenes.len - 1);
+        const index = std.math.clamp(context.data.currentScene, 0, scenes.len - 1);
         scenes[index](context);
 
         context.endFrame();
@@ -79,7 +79,7 @@ fn inspectContext(ctx: *SampleApplication.Context) void {
 
     // Basic toggle
     const glfw = @import("glfw");
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
     if (io.*.KeysData[@intFromEnum(glfw.Key.grave_accent)].DownDuration == 0.0) {
         ctx.data.consoleOpen = !ctx.data.consoleOpen;
     }

--- a/example/src/scenes/colliders.zig
+++ b/example/src/scenes/colliders.zig
@@ -23,7 +23,7 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
     control();
 
     var render = ctx.data.render;
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
 
     // It's important to set the render size, then the camera. This applies the matrices used to display all the sprites.
     render.updateRenderSize(io.*.DisplaySize);
@@ -63,7 +63,7 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
             point.overlaps(pointPos, rect, rectPos) or
             point.overlaps(pointPos, poly, polyPos)) zt.math.Vec4.white else zt.math.vec4(0.0, 0.5, 0.5, 0.7);
 
-        var renderPos = zt.math.rect(point.Point.x + pointPos.x - 1, point.Point.y + pointPos.y - 1, 2, 2);
+        const renderPos = zt.math.rect(point.Point.x + pointPos.x - 1, point.Point.y + pointPos.y - 1, 2, 2);
         render.rectangleHollow(ctx.data.sheet, zt.math.rect(131, 84, 2, 2), renderPos, 0, 4.0, col);
     }
 
@@ -75,9 +75,9 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
             poly.overlaps(polyPos, rect, rectPos)) zt.math.Vec4.white else zt.math.vec4(0.0, 0.5, 0.5, 0.7);
 
         for (poly.Polygon.vertices, 0..) |v, i| {
-            var next = if (i + 1 == poly.Polygon.vertices.len) poly.Polygon.vertices[0] else poly.Polygon.vertices[i + 1];
-            var pos = v.add(polyPos);
-            var nextPos = next.add(polyPos);
+            const next = if (i + 1 == poly.Polygon.vertices.len) poly.Polygon.vertices[0] else poly.Polygon.vertices[i + 1];
+            const pos = v.add(polyPos);
+            const nextPos = next.add(polyPos);
             render.line(ctx.data.sheet, zt.math.rect(131, 84, 2, 2), pos, nextPos, 0, 4.0, col, col);
         }
     }
@@ -86,7 +86,7 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
 }
 
 fn control() void {
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
     ig.igSetNextWindowPos(io.*.DisplaySize, ig.ImGuiCond_Appearing, .{ .x = 1, .y = 1 });
     if (ig.igBegin("Renderer Demo Settings", null, ig.ImGuiWindowFlags_None)) {
         ig.igPushItemWidth(ig.igGetWindowWidth() * 0.5);

--- a/example/src/scenes/renderer.zig
+++ b/example/src/scenes/renderer.zig
@@ -18,7 +18,7 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
     control(ctx);
 
     var render = ctx.data.render;
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
 
     // It's important to set the render size, then the camera. This applies the matrices used to display all the sprites.
     render.updateRenderSize(io.*.DisplaySize);
@@ -61,7 +61,7 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
 }
 
 fn control(ctx: *main.SampleApplication.Context) void {
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
     ig.igSetNextWindowPos(io.*.DisplaySize, ig.ImGuiCond_Appearing, .{ .x = 1, .y = 1 });
     if (ig.igBegin("Renderer Demo Settings", null, ig.ImGuiWindowFlags_None)) {
         ig.igPushItemWidth(ig.igGetWindowWidth() * 0.5);

--- a/example/src/scenes/rendertarget.zig
+++ b/example/src/scenes/rendertarget.zig
@@ -15,14 +15,14 @@ fn ensure() void {
 }
 
 pub fn update(ctx: *main.SampleApplication.Context) void {
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
     ensure();
     control(ctx);
     var render = ctx.data.render;
     render.updateRenderSize(io.*.DisplaySize);
     render.updateCamera(.{}, zoom, rotation);
     render.sprite(ctx.data.sheet, .{}, 0, zt.math.vec2(32, 32), zt.math.Vec4.white, zt.math.vec2(0.5, 0.5), zt.math.rect(16, 0, 16, 16));
-    var pos = render.worldToScreen(.{}); // Cache where the rt is focused
+    const pos = render.worldToScreen(.{}); // Cache where the rt is focused
     render.flush();
 
     // And this is a screenspace transform!
@@ -33,7 +33,7 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
 }
 
 fn control(ctx: *main.SampleApplication.Context) void {
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
     ig.igSetNextWindowPos(io.*.DisplaySize, ig.ImGuiCond_Appearing, .{ .x = 1, .y = 1 });
     if (ig.igBegin("RenderTarget Demo Settings", null, ig.ImGuiWindowFlags_None)) {
         ig.igPushItemWidth(ig.igGetWindowWidth() * 0.5);
@@ -48,12 +48,12 @@ fn control(ctx: *main.SampleApplication.Context) void {
     if (ig.igBegin("RenderTarget Demo Viewer", null, ig.ImGuiWindowFlags_NoScrollbar)) {
         var contentSpace: zt.math.Vec2 = .{};
         ig.igGetContentRegionAvail(&contentSpace);
-        var ratio = contentSpace.x / rt.?.target.width;
+        const ratio = contentSpace.x / rt.?.target.width;
 
         // With opengl and imgui, you need to flip the y source vectors.
-        var uv1 = zt.math.vec2(0, 1);
-        var uv2 = zt.math.vec2(1, 0);
-        var size = zt.math.vec2(contentSpace.x, rt.?.target.height * ratio);
+        const uv1 = zt.math.vec2(0, 1);
+        const uv2 = zt.math.vec2(1, 0);
+        const size = zt.math.vec2(contentSpace.x, rt.?.target.height * ratio);
         ig.igImage(rt.?.target.imguiId(), size, uv1, uv2, zt.math.Vec4.white, zt.math.Vec4.white);
 
         if (ig.igButton("Update RT", .{})) {

--- a/example/src/scenes/shaders.zig
+++ b/example/src/scenes/shaders.zig
@@ -12,7 +12,7 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
     control();
 
     var render = ctx.data.render;
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
     render.updateRenderSize(io.*.DisplaySize);
     render.updateCamera(.{}, scale, rotation);
 
@@ -34,7 +34,7 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
 }
 
 fn control() void {
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
     ig.igSetNextWindowPos(io.*.DisplaySize, ig.ImGuiCond_Appearing, .{ .x = 1, .y = 1 });
     if (ig.igBegin("Renderer Demo Settings", null, ig.ImGuiWindowFlags_None)) {
         ig.igPushItemWidth(ig.igGetWindowWidth() * 0.5);

--- a/example/src/scenes/spatialhash_squares.zig
+++ b/example/src/scenes/spatialhash_squares.zig
@@ -45,7 +45,7 @@ var currentStyle: queryStyle = .point;
 
 pub fn update(ctx: *main.SampleApplication.Context) void {
     // Basic scene initialization:
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
     sceneSetup(ctx);
 
     var render = ctx.data.render;
@@ -63,9 +63,9 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
         .point => {
             var mouse = render.screenToWorld(io.*.MousePos);
             render.sprite(ctx.data.sheet, mouse.sub(zt.math.vec2(-1, 1)), 0.0, zt.math.vec2(2, 2), zt.math.Vec4.white, null, zt.math.rect(131, 84, 2, 2));
-            var query = hash.queryPoint(mouse);
+            const query = hash.queryPoint(mouse);
             for (query) |i| {
-                var b: blip = array.items[i];
+                const b: blip = array.items[i];
 
                 if (zt.game.Physics.isPointInRect(mouse, b.aabb)) {
                     render.sprite(ctx.data.sheet, b.aabb.position, 0.0, b.aabb.size, zt.math.vec4(0.0, 1.0, 0.0, 0.5), null, zt.math.rect(131, 84, 2, 2));
@@ -77,13 +77,13 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
         // We simulate a line drawing by not dragging the start node when holding lmb, and querying the 2.
         .line => {
             const lineCol = zt.math.vec4(0.0, 0.0, 0.0, 1.0);
-            var mouse = render.screenToWorld(io.*.MousePos);
+            const mouse = render.screenToWorld(io.*.MousePos);
             if (!io.*.MouseDown[ig.ImGuiMouseButton_Left]) {
                 line_Q = mouse;
             } else {}
-            var query = hash.queryLine(line_Q, mouse);
+            const query = hash.queryLine(line_Q, mouse);
             for (query) |i| {
-                var b: blip = array.items[i];
+                const b: blip = array.items[i];
 
                 if (zt.game.Physics.isLineInRect(line_Q, mouse, b.aabb.position, b.aabb.size)) {
                     render.sprite(ctx.data.sheet, b.aabb.position, 0.0, b.aabb.size, zt.math.vec4(0.0, 1.0, 0.0, 0.5), null, zt.math.rect(131, 84, 2, 2));
@@ -101,9 +101,9 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
             } else {
                 rect_Q.size = mouse.sub(rect_Q.position);
             }
-            var query = hash.queryAABB(rect_Q.position, rect_Q.size);
+            const query = hash.queryAABB(rect_Q.position, rect_Q.size);
             for (query) |i| {
-                var b: blip = array.items[i];
+                const b: blip = array.items[i];
 
                 if (zt.game.Physics.isRectInRect(rect_Q.position, rect_Q.size, b.aabb.position, b.aabb.size)) {
                     render.sprite(ctx.data.sheet, b.aabb.position, 0.0, b.aabb.size, zt.math.vec4(0.0, 1.0, 0.0, 0.5), null, zt.math.rect(131, 84, 2, 2));
@@ -120,7 +120,7 @@ pub fn update(ctx: *main.SampleApplication.Context) void {
 }
 
 fn control() void {
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
     ig.igSetNextWindowPos(io.*.DisplaySize, ig.ImGuiCond_Appearing, .{ .x = 1, .y = 1 });
     if (ig.igBegin("Spatial Hash Demo", null, ig.ImGuiWindowFlags_None)) {
         ig.igPushItemWidth(ig.igGetWindowWidth() * 0.5);
@@ -143,9 +143,9 @@ fn control() void {
         if (generation) |len| {
             var i: usize = 0;
             while (i < len) : (i += 1) {
-                var new = blip.generate(bounds);
+                const new = blip.generate(bounds);
 
-                var index = array.items.len;
+                const index = array.items.len;
                 array.append(new) catch unreachable;
 
                 hash.addAABB(index, array.items[index].aabb.position, array.items[index].aabb.size);
@@ -172,7 +172,7 @@ fn control() void {
 }
 
 fn sceneSetup(ctx: *main.SampleApplication.Context) void {
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
     if (!inited) {
         var prng = std.rand.DefaultPrng.init(blk: {
             var seed: u64 = undefined;

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ for your game is as smooth as it can be without deciding anything for you
 
 To work with ZT You will need:
 
-- Zig 0.11.* Main branch build
+- Zig 0.11.* Main branch build. Nightly might work as well (last tested `0.12.0-dev.1856+94c63f31f`).
 - Ubuntu: `sudo apt install build-essential xorg-dev`
 
 ### Current Status

--- a/src/pkg/zlm.zig
+++ b/src/pkg/zlm.zig
@@ -1,5 +1,9 @@
 const std = @import("std");
 
+inline fn fabs(v: anytype) @TypeOf(v) {
+    return if (v < 0) -v else v; // TODO: only way to make @fabs vs @abs work with zig-11 vs nightly
+}
+
 /// Makes all vector and matrix types generic against Real
 fn specializeOn(comptime Real: type) type {
     return struct {
@@ -103,7 +107,7 @@ fn specializeOn(comptime Real: type) type {
                 /// returns either a normalized vector (`length() = 1`) or `zero` if the vector
                 /// has length 0.
                 pub fn normalize(vec: Self) Self {
-                    var len = vec.length();
+                    const len = vec.length();
                     return if (len != 0.0)
                         vec.scale(1.0 / vec.length())
                     else
@@ -114,7 +118,7 @@ fn specializeOn(comptime Real: type) type {
                 pub fn abs(a: Self) Self {
                     var result: Self = undefined;
                     inline for (@typeInfo(Self).Struct.fields) |fld| {
-                        @field(result, fld.name) = @fabs(@field(a, fld.name));
+                        @field(result, fld.name) = fabs(@field(a, fld.name));
                     }
                     return result;
                 }
@@ -630,7 +634,7 @@ fn specializeOn(comptime Real: type) type {
             /// `aspect` is the screen aspect ratio (width / height)
             /// `near` is the distance of the near clip plane, whereas `far` is the distance to the far clip plane.
             pub fn createPerspective(fov: Real, aspect: Real, near: Real, far: Real) Mat4 {
-                std.debug.assert(@fabs(aspect - 0.001) > 0);
+                std.debug.assert(fabs(aspect - 0.001) > 0);
 
                 const tanHalfFovy = std.math.tan(fov / 2);
 
@@ -645,11 +649,11 @@ fn specializeOn(comptime Real: type) type {
 
             /// creates a rotation matrix around a certain axis.
             pub fn createAngleAxis(axis: Vec3, angle: Real) Mat4 {
-                var cos = std.math.cos(angle);
-                var sin = std.math.sin(angle);
-                var x = axis.x;
-                var y = axis.y;
-                var z = axis.z;
+                const cos = std.math.cos(angle);
+                const sin = std.math.sin(angle);
+                const x = axis.x;
+                const y = axis.y;
+                const z = axis.z;
 
                 return Mat4{
                     .fields = [4][4]Real{
@@ -664,8 +668,8 @@ fn specializeOn(comptime Real: type) type {
             pub fn createZRotation(radians: f32) Mat4 {
                 var result = Mat4.identity;
 
-                var val1 = @cos(radians);
-                var val2 = @sin(radians);
+                const val1 = @cos(radians);
+                const val2 = @sin(radians);
                 result.fields[0][0] = val1;
                 result.fields[0][1] = val2;
                 result.fields[1][0] = -val2;

--- a/src/zt.zig
+++ b/src/zt.zig
@@ -36,7 +36,7 @@ pub const gl = struct {
 /// to it. Useful to keep relative file loading working properly(especially using `zig build run`)
 /// when ran from any location.
 pub fn makeCwd() !void {
-    var folder = (try known_folders.getPath(std.heap.c_allocator, known_folders.KnownFolder.executable_dir)).?;
+    const folder = (try known_folders.getPath(std.heap.c_allocator, known_folders.KnownFolder.executable_dir)).?;
     try std.os.chdir(folder);
 }
 
@@ -47,7 +47,7 @@ pub inline fn path(subpath: []const u8) []const u8 {
 }
 /// Same as path, but you own the memory.
 pub fn pathEx(allocator: std.mem.Allocator, subpath: []const u8) []const u8 {
-    var executablePath = known_folders.getPath(allocator, .executable_dir) catch unreachable;
+    const executablePath = known_folders.getPath(allocator, .executable_dir) catch unreachable;
     defer allocator.free(executablePath.?);
     return std.fs.path.joinZ(allocator, &[_][]const u8{ executablePath.?, subpath }) catch unreachable;
 }

--- a/src/zt/app.zig
+++ b/src/zt/app.zig
@@ -78,11 +78,11 @@ pub fn App(comptime Data: type) type {
             }
             /// Draws all the imgui commands, and flips the buffer to display the drawn image
             pub fn endFrame(self: *Context) void {
-                var io = ig.igGetIO();
+                const io = ig.igGetIO();
                 // Render
                 if (self.settings.imguiActive) {
                     ig.igRender();
-                    var dd = ig.igGetDrawData();
+                    const dd = ig.igGetDrawData();
                     ImGuiImplementation.RenderDrawData(dd);
                 } else {
                     ig.igEndFrame();
@@ -146,8 +146,8 @@ pub fn App(comptime Data: type) type {
                 glfw.glfwPostEmptyEvent();
             }
             pub fn addFont(self: *Context, path: []const u8, pxSize: f32) *ig.ImFont {
-                var io = ig.igGetIO();
-                var newFont: *ig.ImFont = ig.ImFontAtlas_AddFontFromFileTTF(io.*.Fonts, path.ptr, pxSize, null, ig.ImFontAtlas_GetGlyphRangesDefault(io.*.Fonts));
+                const io = ig.igGetIO();
+                const newFont: *ig.ImFont = ig.ImFontAtlas_AddFontFromFileTTF(io.*.Fonts, path.ptr, pxSize, null, ig.ImFontAtlas_GetGlyphRangesDefault(io.*.Fonts));
                 self.rebuildFont();
                 return newFont;
             }
@@ -155,9 +155,9 @@ pub fn App(comptime Data: type) type {
             /// This is also called for you when you add and remove fonts
             pub fn rebuildFont(self: *Context) void {
                 _ = self;
-                var io = ig.igGetIO();
+                const io = ig.igGetIO();
                 // Delete the old texture
-                var texId = @as(c_uint, @intCast(@intFromPtr(io.*.Fonts.*.TexID)));
+                const texId = @as(c_uint, @intCast(@intFromPtr(io.*.Fonts.*.TexID)));
                 gl.glDeleteTextures(1, &texId);
 
                 // Generate new texture
@@ -238,7 +238,7 @@ pub fn App(comptime Data: type) type {
             gl.glClearColor(0.1, 0.1, 0.12, 1.0);
             const size = self.window.?.getSize();
             gl.glViewport(0, 0, @as(c_int, @intCast(size.width)), @as(c_int, @intCast(size.height)));
-            var io = ig.igGetIO();
+            const io = ig.igGetIO();
             io.*.ConfigFlags |= ig.ImGuiConfigFlags_DockingEnable;
             io.*.DisplaySize = .{ .x = @as(f32, @floatFromInt(size.width)), .y = @as(f32, @floatFromInt(size.height)) };
             self.time = TimeManager.init();
@@ -249,20 +249,20 @@ pub fn App(comptime Data: type) type {
         fn windowSizeChanged(win: glfw.Window, newWidth: u32, newHeight: u32) void {
             _ = win;
             gl.glViewport(0, 0, @as(c_int, @intCast(newWidth)), @as(c_int, @intCast(newHeight)));
-            var io = ig.igGetIO();
+            const io = ig.igGetIO();
             io.*.DisplaySize = .{ .x = @as(f32, @floatFromInt(newWidth)), .y = @as(f32, @floatFromInt(newHeight)) };
         }
         fn windowMaximizeChanged(win: glfw.Window, maximized: bool) void {
             _ = maximized;
             const size = win.getSize();
             gl.glViewport(0, 0, @as(c_int, @intCast(size.width)), @as(c_int, @intCast(size.height)));
-            var io = ig.igGetIO();
+            const io = ig.igGetIO();
             io.*.DisplaySize = .{ .x = @as(f32, @floatFromInt(size.width)), .y = @as(f32, @floatFromInt(size.height)) };
         }
         fn inputCallback(win: glfw.Window, key: glfw.Key, scan: i32, action: glfw.Action, mods: glfw.Mods) void {
             _ = mods;
-            var context: *Context = win.getUserPointer(Context).?;
-            var io = ig.igGetIO();
+            const context: *Context = win.getUserPointer(Context).?;
+            const io = ig.igGetIO();
             var pressed = false;
             if (action == glfw.Action.press or action == glfw.Action.repeat) {
                 pressed = true;
@@ -281,8 +281,8 @@ pub fn App(comptime Data: type) type {
             }) catch unreachable;
         }
         fn mouseWheelCallback(win: glfw.Window, x: f64, y: f64) void {
-            var context: *Context = win.getUserPointer(Context).?;
-            var io = ig.igGetIO();
+            const context: *Context = win.getUserPointer(Context).?;
+            const io = ig.igGetIO();
             io.*.MouseWheel = @as(f32, @floatCast(y));
             io.*.MouseWheelH = @as(f32, @floatCast(x));
             context.input.append(.{ .mouseWheel = .{
@@ -292,8 +292,8 @@ pub fn App(comptime Data: type) type {
         }
         fn mousebuttonCallback(win: glfw.Window, key: glfw.MouseButton, action: glfw.Action, mods: glfw.Mods) void {
             _ = mods;
-            var context: *Context = win.getUserPointer(Context).?;
-            var io = ig.igGetIO();
+            const context: *Context = win.getUserPointer(Context).?;
+            const io = ig.igGetIO();
             var pressed = false;
             if (action == glfw.Action.press or action == glfw.Action.repeat) {
                 pressed = true;
@@ -319,8 +319,8 @@ pub fn App(comptime Data: type) type {
             }) catch unreachable;
         }
         fn cursorCallback(win: glfw.Window, x: f64, y: f64) void {
-            var context: *Context = win.getUserPointer(Context).?;
-            var io = ig.igGetIO();
+            const context: *Context = win.getUserPointer(Context).?;
+            const io = ig.igGetIO();
             io.*.MousePos = .{ .x = @as(f32, @floatCast(x)), .y = @as(f32, @floatCast(y)) };
             context.input.append(.{ .mousePosition = .{
                 .x = x,
@@ -328,8 +328,8 @@ pub fn App(comptime Data: type) type {
             } }) catch unreachable;
         }
         fn charCallback(win: glfw.Window, char: u21) void {
-            var context: *Context = win.getUserPointer(Context).?;
-            var io = ig.igGetIO();
+            const context: *Context = win.getUserPointer(Context).?;
+            const io = ig.igGetIO();
             ig.ImGuiIO_AddInputCharacter(io, char);
             context.input.append(.{ .character = .{
                 .value = char,

--- a/src/zt/customComponents.zig
+++ b/src/zt/customComponents.zig
@@ -21,17 +21,17 @@ pub fn viewPort() ig.ImGuiID {
         ig.ImGuiWindowFlags_NoInputs |
         ig.ImGuiWindowFlags_NoBringToFrontOnFocus;
 
-    var mainView = ig.igGetMainViewport();
+    const mainView = ig.igGetMainViewport();
 
-    var pos: ig.ImVec2 = mainView.*.WorkPos;
-    var size: ig.ImVec2 = mainView.*.WorkSize;
+    const pos: ig.ImVec2 = mainView.*.WorkPos;
+    const size: ig.ImVec2 = mainView.*.WorkSize;
 
     ig.igSetNextWindowPos(pos, ig.ImGuiCond_Always, .{});
     ig.igSetNextWindowSize(size, ig.ImGuiCond_Always);
 
     ig.igPushStyleVar_Vec2(ig.ImGuiStyleVar_WindowPadding, .{});
     _ = ig.igBegin("###DockSpace", null, windowFlags);
-    var id = ig.igGetID_Str("DefaultDockingViewport");
+    const id = ig.igGetID_Str("DefaultDockingViewport");
     _ = ig.igDockSpace(id, .{}, dockNodeFlags, ig.ImGuiWindowClass_ImGuiWindowClass());
 
     ig.igEnd();
@@ -90,8 +90,8 @@ pub fn editDrag(label: []const u8, speed: f32, ptr: anytype) bool {
             return ig.igDragFloat(label.ptr, ptr, speed, -fmax, fmax, "%.2f", ig.ImGuiSliderFlags_NoRoundToFormat);
         },
         *usize => {
-            var cast = @as(c_int, @intCast(ptr.*));
-            var result = ig.igInputInt(label.ptr, &cast, 1, 5, ig.ImGuiInputTextFlags_None);
+            const cast = @as(c_int, @intCast(ptr.*));
+            const result = ig.igInputInt(label.ptr, &cast, 1, 5, ig.ImGuiInputTextFlags_None);
             if (result) {
                 ptr.* = @intCast(std.math.max(0, cast));
             }
@@ -99,7 +99,7 @@ pub fn editDrag(label: []const u8, speed: f32, ptr: anytype) bool {
         },
         *zt.math.Vec2 => {
             var cast: [2]f32 = .{ ptr.*.x, ptr.*.y };
-            var result = ig.igDragFloat2(label.ptr, &cast, speed, -fmax, fmax, "%.2f", ig.ImGuiSliderFlags_NoRoundToFormat);
+            const result = ig.igDragFloat2(label.ptr, &cast, speed, -fmax, fmax, "%.2f", ig.ImGuiSliderFlags_NoRoundToFormat);
             if (result) {
                 ptr.* = zt.math.vec2(cast[0], cast[1]);
             }
@@ -107,7 +107,7 @@ pub fn editDrag(label: []const u8, speed: f32, ptr: anytype) bool {
         },
         *zt.math.Vec3 => {
             var cast: [3]f32 = .{ ptr.*.x, ptr.*.y, ptr.*.z };
-            var result = ig.igDragFloat3(label.ptr, &cast, speed, -fmax, fmax, "%.2f", ig.ImGuiSliderFlags_NoRoundToFormat);
+            const result = ig.igDragFloat3(label.ptr, &cast, speed, -fmax, fmax, "%.2f", ig.ImGuiSliderFlags_NoRoundToFormat);
             if (result) {
                 ptr.* = zt.math.vec3(cast[0], cast[1], cast[2]);
             }
@@ -115,7 +115,7 @@ pub fn editDrag(label: []const u8, speed: f32, ptr: anytype) bool {
         },
         *zt.math.Vec4 => {
             var cast: [4]f32 = .{ ptr.*.x, ptr.*.y, ptr.*.z, ptr.*.w };
-            var result = ig.igColorEdit4(label.ptr, &cast, ig.ImGuiColorEditFlags_Float);
+            const result = ig.igColorEdit4(label.ptr, &cast, ig.ImGuiColorEditFlags_Float);
             if (result) {
                 ptr.* = zt.math.vec4(cast[0], cast[1], cast[2], cast[3]);
             }
@@ -123,7 +123,7 @@ pub fn editDrag(label: []const u8, speed: f32, ptr: anytype) bool {
         },
         *zt.math.Rect => {
             var cast: [4]f32 = .{ ptr.*.position.x, ptr.*.position.y, ptr.*.size.x, ptr.*.size.y };
-            var result = ig.igDragFloat4(label.ptr, &cast, speed, -fmax, fmax, "%.2f", ig.ImGuiSliderFlags_NoRoundToFormat);
+            const result = ig.igDragFloat4(label.ptr, &cast, speed, -fmax, fmax, "%.2f", ig.ImGuiSliderFlags_NoRoundToFormat);
             if (result) {
                 ptr.* = zt.math.rect(cast[0], cast[1], cast[2], cast[3]);
             }
@@ -155,40 +155,40 @@ pub fn edit(label: []const u8, ptr: anytype) bool {
             return ig.igInputFloat(label.ptr, ptr, 1, 3, "%.2f", ig.ImGuiInputTextFlags_None);
         },
         *usize => {
-            var cast = @as(c_int, @intCast(ptr.*));
-            var result = ig.igInputInt(label.ptr, &cast, 1, 5, ig.ImGuiInputTextFlags_None);
+            const cast = @as(c_int, @intCast(ptr.*));
+            const result = ig.igInputInt(label.ptr, &cast, 1, 5, ig.ImGuiInputTextFlags_None);
             if (result) {
                 ptr.* = @intCast(std.math.max(0, cast));
             }
             return result;
         },
         *zt.math.Vec2 => {
-            var cast: [2]f32 = .{ ptr.*.x, ptr.*.y };
-            var result = ig.igInputFloat2(label.ptr, &cast, "%.2f", ig.ImGuiInputTextFlags_None);
+            const cast: [2]f32 = .{ ptr.*.x, ptr.*.y };
+            const result = ig.igInputFloat2(label.ptr, &cast, "%.2f", ig.ImGuiInputTextFlags_None);
             if (result) {
                 ptr.* = zt.math.vec2(cast[0], cast[1]);
             }
             return result;
         },
         *zt.math.Vec3 => {
-            var cast: [3]f32 = .{ ptr.*.x, ptr.*.y, ptr.*.z };
-            var result = ig.igInputFloat3(label.ptr, &cast, "%.2f", ig.ImGuiInputTextFlags_None);
+            const cast: [3]f32 = .{ ptr.*.x, ptr.*.y, ptr.*.z };
+            const result = ig.igInputFloat3(label.ptr, &cast, "%.2f", ig.ImGuiInputTextFlags_None);
             if (result) {
                 ptr.* = zt.math.vec3(cast[0], cast[1], cast[2]);
             }
             return result;
         },
         *zt.math.Vec4 => {
-            var cast: [4]f32 = .{ ptr.*.x, ptr.*.y, ptr.*.z, ptr.*.w };
-            var result = ig.igColorEdit4(label.ptr, &cast, ig.ImGuiColorEditFlags_Float);
+            const cast: [4]f32 = .{ ptr.*.x, ptr.*.y, ptr.*.z, ptr.*.w };
+            const result = ig.igColorEdit4(label.ptr, &cast, ig.ImGuiColorEditFlags_Float);
             if (result) {
                 ptr.* = zt.math.vec4(cast[0], cast[1], cast[2], cast[3]);
             }
             return result;
         },
         *zt.math.Rect => {
-            var cast: [4]f32 = .{ ptr.*.position.x, ptr.*.position.y, ptr.*.size.x, ptr.*.size.y };
-            var result = ig.igInputFloat4(label.ptr, &cast, "%.2f", ig.ImGuiInputTextFlags_None);
+            const cast: [4]f32 = .{ ptr.*.position.x, ptr.*.position.y, ptr.*.size.x, ptr.*.size.y };
+            const result = ig.igInputFloat4(label.ptr, &cast, "%.2f", ig.ImGuiInputTextFlags_None);
             if (result) {
                 ptr.* = zt.math.rect(cast[0], cast[1], cast[2], cast[3]);
             }

--- a/src/zt/generateBuffer.zig
+++ b/src/zt/generateBuffer.zig
@@ -67,7 +67,7 @@ pub fn GenerateBuffer(comptime T: type, comptime V: usize) type {
             gl.glBindBuffer(gl.GL_ELEMENT_ARRAY_BUFFER, self.iboId);
 
             var currentOffset: usize = 0;
-            var stride: c_int = @intCast(@sizeOf(T));
+            const stride: c_int = @intCast(@sizeOf(T));
 
             inline for (std.meta.fields(T), 0..) |field, i| {
                 switch (field.type) {
@@ -205,8 +205,8 @@ pub fn GenerateBuffer(comptime T: type, comptime V: usize) type {
                 return;
             }
             self.bind();
-            var vertSize: c_longlong = @intCast(@sizeOf(T) * self.vertCount);
-            var indSize: c_longlong = @intCast(@sizeOf(c_uint) * self.indCount);
+            const vertSize: c_longlong = @intCast(@sizeOf(T) * self.vertCount);
+            const indSize: c_longlong = @intCast(@sizeOf(c_uint) * self.indCount);
             gl.glBufferData(gl.GL_ARRAY_BUFFER, vertSize, &self.vertices, gl.GL_STATIC_DRAW);
             gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER, indSize, &self.indices, gl.GL_STATIC_DRAW);
             self.unbind();
@@ -219,8 +219,8 @@ pub fn GenerateBuffer(comptime T: type, comptime V: usize) type {
                 return;
             }
             self.bind();
-            var vertSize: c_longlong = @intCast(@sizeOf(T) * self.vertCount);
-            var indSize: c_longlong = @intCast(@sizeOf(c_uint) * self.indCount);
+            const vertSize: c_longlong = @intCast(@sizeOf(T) * self.vertCount);
+            const indSize: c_longlong = @intCast(@sizeOf(c_uint) * self.indCount);
             gl.glBufferData(gl.GL_ARRAY_BUFFER, vertSize, &self.vertices, gl.GL_DYNAMIC_DRAW);
             gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER, indSize, &self.indices, gl.GL_DYNAMIC_DRAW);
             self.unbind();
@@ -233,8 +233,8 @@ pub fn GenerateBuffer(comptime T: type, comptime V: usize) type {
                 return;
             }
             self.bind();
-            var vertSize: c_longlong = @intCast(@sizeOf(T) * self.vertCount);
-            var indSize: c_longlong = @intCast(@sizeOf(c_uint) * self.indCount);
+            const vertSize: c_longlong = @intCast(@sizeOf(T) * self.vertCount);
+            const indSize: c_longlong = @intCast(@sizeOf(c_uint) * self.indCount);
             gl.glBufferData(gl.GL_ARRAY_BUFFER, vertSize, &self.vertices, gl.GL_STREAM_DRAW);
             gl.glBufferData(gl.GL_ELEMENT_ARRAY_BUFFER, indSize, &self.indices, gl.GL_STREAM_DRAW);
             self.unbind();
@@ -252,7 +252,7 @@ pub fn GenerateBuffer(comptime T: type, comptime V: usize) type {
         }
 
         pub fn setUniform(self: *@This(), comptime uniName: []const u8, uniform: anytype) void {
-            var loc: c_int = gl.glGetUniformLocation(self.shader.id, uniName.ptr);
+            const loc: c_int = gl.glGetUniformLocation(self.shader.id, uniName.ptr);
             self.shader.bind();
             if (loc != -1) {
                 switch (@TypeOf(uniform)) {

--- a/src/zt/imguiImplementation.zig
+++ b/src/zt/imguiImplementation.zig
@@ -22,7 +22,7 @@ var g_ElementsHandle: c_uint = 0;
 
 // Functions
 pub fn init(glsl_version_opt: ?[:0]const u8) void {
-    var ctx = ig.igCreateContext(null);
+    const ctx = ig.igCreateContext(null);
     ig.igSetCurrentContext(ctx);
     // Query for GL version
     var major: gl.GLint = undefined;
@@ -32,7 +32,7 @@ pub fn init(glsl_version_opt: ?[:0]const u8) void {
     g_GlVersion = @as(gl.GLuint, @intCast(major * 1000 + minor));
 
     // Setup back-end capabilities flags
-    var io = ig.igGetIO();
+    const io = ig.igGetIO();
     io.*.BackendRendererName = "imgui_impl_opengl3";
     io.*.IniFilename = "workspace";
     // Sensible memory-friendly initial mouse position.
@@ -48,7 +48,7 @@ pub fn init(glsl_version_opt: ?[:0]const u8) void {
     }
 
     std.debug.assert(glsl_version.len + 2 < g_GlslVersionStringMem.len);
-    std.mem.copy(u8, g_GlslVersionStringMem[0..glsl_version.len], glsl_version);
+    @memcpy(g_GlslVersionStringMem[0..glsl_version.len], glsl_version);
     g_GlslVersionStringMem[glsl_version.len] = '\n';
     g_GlslVersionStringMem[glsl_version.len + 1] = 0;
     g_GlslVersionString = g_GlslVersionStringMem[0..glsl_version.len];
@@ -104,10 +104,10 @@ fn SetupRenderState(draw_data: *ig.ImDrawData, fb_width: c_int, fb_height: c_int
     // Setup viewport, orthographic projection matrix
     // Our visible imgui space lies from draw_data.DisplayPos (top left) to draw_data.DisplayPos+data_data.DisplaySize (bottom right). DisplayPos is (0,0) for single viewport apps.
     gl.glViewport(0, 0, @as(gl.GLsizei, @intCast(fb_width)), @as(gl.GLsizei, @intCast(fb_height)));
-    var L = draw_data.DisplayPos.x;
-    var R = draw_data.DisplayPos.x + draw_data.DisplaySize.x;
-    var T = draw_data.DisplayPos.y;
-    var B = draw_data.DisplayPos.y + draw_data.DisplaySize.y;
+    const L = draw_data.DisplayPos.x;
+    const R = draw_data.DisplayPos.x + draw_data.DisplaySize.x;
+    const T = draw_data.DisplayPos.y;
+    const B = draw_data.DisplayPos.y + draw_data.DisplaySize.y;
     const ortho_projection = [4][4]f32{
         [4]f32{ 2.0 / (R - L), 0.0, 0.0, 0.0 },
         [4]f32{ 0.0, 2.0 / (T - B), 0.0, 0.0 },
@@ -155,20 +155,20 @@ fn SetupRenderState(draw_data: *ig.ImDrawData, fb_width: c_int, fb_height: c_int
 }
 
 fn getGLInt(name: gl.GLenum) gl.GLint {
-    var value: gl.GLint = undefined;
+    const value: gl.GLint = undefined;
     gl.glGetIntegerv(name, &value);
     return value;
 }
 fn getGLInts(name: gl.GLenum, comptime N: comptime_int) [N]gl.GLint {
-    var value: [N]gl.GLint = undefined;
+    const value: [N]gl.GLint = undefined;
     gl.glGetIntegerv(name, &value);
     return value;
 }
 
 pub fn RenderDrawData(draw_data: *ig.ImDrawData) void {
     // Avoid rendering when minimized, scale coordinates for retina displays (screen coordinates != framebuffer coordinates)
-    var fb_width = @as(c_int, @intFromFloat(draw_data.DisplaySize.x * draw_data.FramebufferScale.x));
-    var fb_height = @as(c_int, @intFromFloat(draw_data.DisplaySize.y * draw_data.FramebufferScale.y));
+    const fb_width = @as(c_int, @intFromFloat(draw_data.DisplaySize.x * draw_data.FramebufferScale.x));
+    const fb_height = @as(c_int, @intFromFloat(draw_data.DisplaySize.y * draw_data.FramebufferScale.y));
     if (fb_width <= 0 or fb_height <= 0)
         return;
 
@@ -176,8 +176,8 @@ pub fn RenderDrawData(draw_data: *ig.ImDrawData) void {
     gl.glGenVertexArrays(1, &vertex_array_object);
     SetupRenderState(draw_data, fb_width, fb_height, vertex_array_object);
 
-    var clip_off = draw_data.DisplayPos; // (0,0) unless using multi-viewports
-    var clip_scale = draw_data.FramebufferScale; // (1,1) unless using retina display which are often (2,2)
+    const clip_off = draw_data.DisplayPos; // (0,0) unless using multi-viewports
+    const clip_scale = draw_data.FramebufferScale; // (1,1) unless using retina display which are often (2,2)
 
     if (draw_data.CmdListsCount > 0) {
         for (draw_data.CmdLists[0..@as(usize, @intCast(draw_data.CmdListsCount))]) |cmd_list| {
@@ -190,7 +190,7 @@ pub fn RenderDrawData(draw_data: *ig.ImDrawData) void {
                     fnPtr(cmd_list, &pcmd);
                 } else {
                     // Project scissor/clipping rectangles into framebuffer space
-                    var clip_rect = ig.ImVec4{
+                    const clip_rect = ig.ImVec4{
                         .x = (pcmd.ClipRect.x - clip_off.x) * clip_scale.x,
                         .y = (pcmd.ClipRect.y - clip_off.y) * clip_scale.y,
                         .z = (pcmd.ClipRect.z - clip_off.x) * clip_scale.x,

--- a/src/zt/physics.zig
+++ b/src/zt/physics.zig
@@ -42,35 +42,35 @@ pub fn isPointInPolygon(point: math.Vec2, polyPoint: math.Vec2, vertices: []math
 }
 pub fn isCircleInPolygon(circlePos: math.Vec2, radius: f32, polygonPos: math.Vec2, vertices: []math.Vec2) bool {
     for (vertices, 0..) |vert, i| {
-        var next = if (i + 1 == vertices.len) polygonPos.add(vertices[0]) else polygonPos.add(vertices[i + 1]);
+        const next = if (i + 1 == vertices.len) polygonPos.add(vertices[0]) else polygonPos.add(vertices[i + 1]);
         if (isLineInCircle(vert.add(polygonPos), next, circlePos, radius)) return true;
     }
     return isPointInPolygon(circlePos, polygonPos, vertices);
 }
 pub fn isLineInPolygon(lineStart: math.Vec2, lineEnd: math.Vec2, polygonPos: math.Vec2, vertices: []math.Vec2) bool {
     for (vertices, 0..) |vert, i| {
-        var next = if (i + 1 == vertices.len) polygonPos.add(vertices[0]) else polygonPos.add(vertices[i + 1]);
+        const next = if (i + 1 == vertices.len) polygonPos.add(vertices[0]) else polygonPos.add(vertices[i + 1]);
         if (isLineInLine(lineStart, lineEnd, vert.add(polygonPos), next)) return true;
     }
     return false;
 }
 pub fn isPolygonInPolygon(polygonPos: math.Vec2, vertices: []math.Vec2, polygon2Pos: math.Vec2, vertices2: []math.Vec2) bool {
     for (vertices, 0..) |vert, i| {
-        var next = if (i + 1 == vertices.len) polygonPos.add(vertices[0]) else polygonPos.add(vertices[i + 1]);
+        const next = if (i + 1 == vertices.len) polygonPos.add(vertices[0]) else polygonPos.add(vertices[i + 1]);
         if (isLineInPolygon(vert.add(polygonPos), next, polygon2Pos, vertices2)) return true;
     }
     return isPointInPolygon(polygonPos, polygon2Pos, vertices2);
 }
 pub fn isRectInPolygon(rectangle: math.Rect, polygonPos: math.Vec2, vertices: []math.Vec2) bool {
     for (vertices, 0..) |vert, i| {
-        var next = if (i + 1 == vertices.len) polygonPos.add(vertices[0]) else polygonPos.add(vertices[i + 1]);
+        const next = if (i + 1 == vertices.len) polygonPos.add(vertices[0]) else polygonPos.add(vertices[i + 1]);
         if (isLineInRect(vert.add(polygonPos), next, rectangle.position, rectangle.size)) return true;
     }
     return isPointInPolygon(rectangle.position, polygonPos, vertices);
 }
 pub fn isLineInLine(l1Start: math.Vec2, l1End: math.Vec2, l2Start: math.Vec2, l2End: math.Vec2) bool {
-    var uA: f32 = ((l2End.x - l2Start.x) * (l1Start.y - l2Start.y) - (l2End.y - l2Start.y) * (l1Start.x - l2Start.x)) / ((l2End.y - l2Start.y) * (l1End.x - l1Start.x) - (l2End.x - l2Start.x) * (l1End.y - l1Start.y));
-    var uB: f32 = ((l1End.x - l1Start.x) * (l1Start.y - l2Start.y) - (l1End.y - l1Start.y) * (l1Start.x - l2Start.x)) / ((l2End.y - l2Start.y) * (l1End.x - l1Start.x) - (l2End.x - l2Start.x) * (l1End.y - l1Start.y));
+    const uA: f32 = ((l2End.x - l2Start.x) * (l1Start.y - l2Start.y) - (l2End.y - l2Start.y) * (l1Start.x - l2Start.x)) / ((l2End.y - l2Start.y) * (l1End.x - l1Start.x) - (l2End.x - l2Start.x) * (l1End.y - l1Start.y));
+    const uB: f32 = ((l1End.x - l1Start.x) * (l1Start.y - l2Start.y) - (l1End.y - l1Start.y) * (l1Start.x - l2Start.x)) / ((l2End.y - l2Start.y) * (l1End.x - l1Start.x) - (l2End.x - l2Start.x) * (l1End.y - l1Start.y));
     return (uA >= 0 and uA <= 1 and uB >= 0 and uB <= 1);
 }
 pub fn isLineInRect(line1: math.Vec2, line2: math.Vec2, aabbPos: math.Vec2, aabbSize: math.Vec2) bool {
@@ -101,9 +101,9 @@ pub fn isCircleInRect(circPos: math.Vec2, radius: f32, rectPos: math.Vec2, rectS
         testY = rectPos.y + rectSize.y;
     }
 
-    var distX = circPos.x - testX;
-    var distY = circPos.y - testY;
-    var dist = std.math.sqrt((distX * distX) + (distY * distY));
+    const distX = circPos.x - testX;
+    const distY = circPos.y - testY;
+    const dist = std.math.sqrt((distX * distX) + (distY * distY));
 
     return dist <= radius;
 }
@@ -122,10 +122,10 @@ pub fn isLineInCircle(lineStart: math.Vec2, lineEnd: math.Vec2, circlePos: math.
     const closestX = lineStart.x + (dot * (lineEnd.x - lineStart.x));
     const closestY = lineStart.y + (dot * (lineEnd.y - lineStart.y));
 
-    var onSegment = isPointInLine(.{ .x = closestX, .y = closestY }, lineStart, lineEnd);
+    const onSegment = isPointInLine(.{ .x = closestX, .y = closestY }, lineStart, lineEnd);
     if (!onSegment) return false;
 
-    var closest = math.vec2(closestX - circlePos.x, closestY - circlePos.y);
+    const closest = math.vec2(closestX - circlePos.x, closestY - circlePos.y);
 
     return closest.length() <= radius;
 }
@@ -379,11 +379,11 @@ pub const Shape = union(enum) {
 };
 
 test "Overlap methods" {
-    var offsetPoint = Shape.point(.{ .x = -20 });
-    var testPoint = Shape.point(.{});
-    var testCircle = Shape.circle(10);
-    var testRectangle = Shape.rectangle(.{}, .{ .x = 10, .y = 10 });
-    var offsetRectangle = Shape.rectangle(.{ .x = 20 }, .{ .x = 10, .y = 10 });
+    const offsetPoint = Shape.point(.{ .x = -20 });
+    const testPoint = Shape.point(.{});
+    const testCircle = Shape.circle(10);
+    const testRectangle = Shape.rectangle(.{}, .{ .x = 10, .y = 10 });
+    const offsetRectangle = Shape.rectangle(.{ .x = 20 }, .{ .x = 10, .y = 10 });
 
     // Point -> Circle
     assert(isPointInCircle(.{}, .{}, 3));
@@ -401,13 +401,13 @@ test "Overlap methods" {
     assert(!Shape.overlaps(testPoint, .{}, offsetRectangle, .{}));
 
     // Point -> Poly
-    var polygons: []math.Vec2 = &.{
+    const polygons: []math.Vec2 = &.{
         math.vec2(-10, 0),
         math.vec2(0, -10),
         math.vec2(10, 0),
         math.vec2(0, 10),
     };
-    var testPoly = Shape{ .Polygon = .{ .vertices = polygons } };
+    const testPoly = Shape{ .Polygon = .{ .vertices = polygons } };
     assert(isPointInPolygon(.{}, .{}, polygons));
     assert(!isPointInPolygon(math.vec2(-8, -8), .{}, polygons));
     assert(Shape.overlaps(testPoint, .{}, testPoly, .{}));

--- a/src/zt/renderer.zig
+++ b/src/zt/renderer.zig
@@ -109,25 +109,25 @@ pub fn spriteEx(self: *Self, texture: zt.gl.Texture, x: f32, y: f32, z: f32, w: 
         self.flush();
         self.currentTexture = texture;
     }
-    var start: zt.math.Vec3 = zt.math.Vec3.new(x, y, z);
-    var end: zt.math.Vec3 = zt.math.Vec3.new(x + w, y + h, z);
+    const start: zt.math.Vec3 = zt.math.Vec3.new(x, y, z);
+    const end: zt.math.Vec3 = zt.math.Vec3.new(x + w, y + h, z);
 
-    var tl = Vertex{
+    const tl = Vertex{
         .pos = .{ .x = start.x, .y = start.y, .z = start.z },
         .col = colTl,
         .tex = .{ .x = sx, .y = sy },
     };
-    var tr = Vertex{
+    const tr = Vertex{
         .pos = .{ .x = end.x, .y = start.y, .z = start.z },
         .col = colTr,
         .tex = .{ .x = sx + sw, .y = sy },
     };
-    var bl = Vertex{
+    const bl = Vertex{
         .pos = .{ .x = start.x, .y = end.y, .z = start.z },
         .col = colBl,
         .tex = .{ .x = sx, .y = sy + sh },
     };
-    var br = Vertex{
+    const br = Vertex{
         .pos = .{ .x = end.x, .y = end.y, .z = start.z },
         .col = colBr,
         .tex = .{ .x = sx + sw, .y = sy + sh },
@@ -159,25 +159,25 @@ pub fn line(self: *Self, texture: zt.gl.Texture, sourceRect: ?zt.math.Rect, star
         zt.math.rect(0, 0, 1, 1);
 
     const direction: zt.math.Vec2 = end.sub(start).normalize();
-    var leftOffset: zt.math.Vec3 = zt.math.vec3(direction.y, -direction.x, 0).scale(width * 0.5);
-    var rightOffset: zt.math.Vec3 = leftOffset.scale(-1);
+    const leftOffset: zt.math.Vec3 = zt.math.vec3(direction.y, -direction.x, 0).scale(width * 0.5);
+    const rightOffset: zt.math.Vec3 = leftOffset.scale(-1);
 
-    var tl = Vertex{
+    const tl = Vertex{
         .pos = zt.math.vec3(start.x, start.y, z).add(leftOffset),
         .col = colStarT,
         .tex = .{ .x = source.position.x, .y = source.position.y },
     };
-    var tr = Vertex{
+    const tr = Vertex{
         .pos = zt.math.vec3(start.x, start.y, z).add(rightOffset),
         .col = colStarT,
         .tex = .{ .x = source.position.x + source.size.x, .y = source.position.y },
     };
-    var bl = Vertex{
+    const bl = Vertex{
         .pos = zt.math.vec3(end.x, end.y, z).add(leftOffset),
         .col = colEnd,
         .tex = .{ .x = source.position.x, .y = source.position.y + source.size.y },
     };
-    var br = Vertex{
+    const br = Vertex{
         .pos = zt.math.vec3(end.x, end.y, z).add(rightOffset),
         .col = colEnd,
         .tex = .{ .x = source.position.x + source.size.x, .y = source.position.y + source.size.y },
@@ -213,17 +213,17 @@ pub fn circle(self: *Self, texture: zt.gl.Texture, sourceRect: ?zt.math.Rect, ta
         zt.math.rect(0, 0, 1, 1);
 
     while (i < triCount) : (i += 1) {
-        var c = Vertex{
+        const c = Vertex{
             .pos = zt.math.vec3(target.x, target.y, z),
             .col = col,
             .tex = .{ .x = source.position.x, .y = source.position.y },
         };
-        var l = Vertex{
+        const l = Vertex{
             .pos = zt.math.vec3(target.x + (radius * @cos(@as(f32, @floatFromInt(i)) * twoPi / @as(f32, @floatFromInt(triCount)))), target.y + (radius * @sin(@as(f32, @floatFromInt(i)) * twoPi / @as(f32, @floatFromInt(triCount)))), z),
             .col = col,
             .tex = .{ .x = source.position.x + source.size.x, .y = source.position.y },
         };
-        var r = Vertex{
+        const r = Vertex{
             .pos = zt.math.vec3(target.x + (radius * @cos(@as(f32, @floatFromInt(i + 1)) * twoPi / @as(f32, @floatFromInt(triCount)))), target.y + (radius * @sin(@as(f32, @floatFromInt(i + 1)) * twoPi / @as(f32, @floatFromInt(triCount)))), z),
             .col = col,
             .tex = .{ .x = source.position.x, .y = source.position.y + source.size.y },
@@ -251,9 +251,9 @@ pub fn rectangleHollow(self: *Self, texture: zt.gl.Texture, sourceRect: ?zt.math
 pub fn text(self: *Self, pos: zt.math.Vec2, string: []const u8, col: zt.math.Vec4) void {
     _ = self;
     const ig = @import("imgui");
-    var drawlist = ig.igGetBackgroundDrawList_Nil();
+    const drawlist = ig.igGetBackgroundDrawList_Nil();
 
-    var colCast: [4]u8 = .{
+    const colCast: [4]u8 = .{
         @intFromFloat(255 * col.x),
         @intFromFloat(255 * col.y),
         @intFromFloat(255 * col.z),

--- a/src/zt/shader.zig
+++ b/src/zt/shader.zig
@@ -13,11 +13,11 @@ pub fn from(shaderID: c_uint) Self {
 pub fn init(vert: [*:0]const u8, frag: [*:0]const u8) Self {
     var self: Self = .{};
 
-    var vertId = gl.glCreateShader(gl.GL_VERTEX_SHADER);
+    const vertId = gl.glCreateShader(gl.GL_VERTEX_SHADER);
     gl.glShaderSource(vertId, 1, &vert, null);
     gl.glCompileShader(vertId);
 
-    var fragId = gl.glCreateShader(gl.GL_FRAGMENT_SHADER);
+    const fragId = gl.glCreateShader(gl.GL_FRAGMENT_SHADER);
     gl.glShaderSource(fragId, 1, &frag, null);
     gl.glCompileShader(fragId);
 

--- a/src/zt/styler.zig
+++ b/src/zt/styler.zig
@@ -6,7 +6,7 @@ const math = zt.math;
 /// Sets imgui style to be compact, does not affect colors. Recommended to follow this up
 /// with your own custom colors, or one from this file `styleColor*()`
 pub fn styleSizeCompact() void {
-    var style = ig.igGetStyle();
+    const style = ig.igGetStyle();
 
     // Paddings
     style.*.WindowPadding = .{ .x = 4, .y = 4 };
@@ -58,7 +58,7 @@ pub fn styleColorCustom(background: ig.ImVec4, foreground: ig.ImVec4, highlight:
     const sp1 = special;
     const sp2 = if (isLightTheme) special.brighten(-contrast) else special.brighten(contrast);
 
-    var style = ig.igGetStyle();
+    const style = ig.igGetStyle();
     style.*.Colors[ig.ImGuiCol_Text] = fg1;
     style.*.Colors[ig.ImGuiCol_TextDisabled] = fg0;
     style.*.Colors[ig.ImGuiCol_WindowBg] = bg0;

--- a/src/zt/texture.zig
+++ b/src/zt/texture.zig
@@ -19,12 +19,12 @@ pub fn from(id: c_uint, inDepth: bool) Self {
 }
 /// Takes a file path and loads it into opengl using stb_image.
 pub fn init(filePath: []const u8) !Self {
-    var ownedFp: [:0]const u8 = try std.heap.c_allocator.dupeZ(u8, filePath);
+    const ownedFp: [:0]const u8 = try std.heap.c_allocator.dupeZ(u8, filePath);
     defer std.heap.c_allocator.free(ownedFp);
     var w: c_int = 0;
     var h: c_int = 0;
     var numChannels: c_int = 0;
-    var data = stb.stbi_load(ownedFp.ptr, &w, &h, &numChannels, 0);
+    const data = stb.stbi_load(ownedFp.ptr, &w, &h, &numChannels, 0);
     var self = Self{};
 
     self.width = @floatFromInt(w);
@@ -75,7 +75,7 @@ pub fn initMemory(slice: []const u8) !Self {
     var w: c_int = 0;
     var h: c_int = 0;
     var numChannels: c_int = 0;
-    var data = stb.stbi_load_from_memory(slice.ptr, @intCast(slice.len), &w, &h, &numChannels, 0);
+    const data = stb.stbi_load_from_memory(slice.ptr, @intCast(slice.len), &w, &h, &numChannels, 0);
 
     var self = Self{};
 

--- a/src/zt/timeManager.zig
+++ b/src/zt/timeManager.zig
@@ -15,7 +15,7 @@ pub fn init() @This() {
     };
 }
 pub fn tick(self: *Self) void {
-    var lap = glfw.getTime();
+    const lap = glfw.getTime();
 
     // No need to worry about overflow, unless a frame intends to last for over a month.
     self.dt = @as(f32, @floatCast(lap - self._previous));
@@ -23,7 +23,7 @@ pub fn tick(self: *Self) void {
 
     // Smoothly introduce new fps measurements.
     const smoothing: f32 = 0.99;
-    var newFps = 1.0 / self.dt;
+    const newFps = 1.0 / self.dt;
     self.fps = (self.fps * smoothing) + (newFps * (1.0 - smoothing));
 
     self._previous = lap;


### PR DESCRIPTION
Tested with zig `0.11.0` and `0.12.0-dev.1856+94c63f31f` on Windows x64.
Changes:
* const vs vars (a lot of them)
* use TranslateC from build.zig for some of the source files which had issues. Those pre-generated source files I think could be removed in future. Stopped at imgui as I didn't figure out how to generate it in a way that it uses zlm types.
* fabs vs abs rename fix. Unfortionately could not get it switching at comptime as its builtin function. Just implemented it as regular inline fn
* `addCSourceFiles` has api change, switched just to `addCSourceFile` as its api stays the same
* std had few other std api changes, selects correct implementation at comptime
* disabled `known_folders.zig` implementation with zig > 11, seems nothing uses it, but it didn't compile.